### PR TITLE
Fix dead link to blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the client library for rendering the image previews.
 
-Look at [this blog post](http://q42.com/blog/post/133591843068/imagepreview-library) for more details.
+Look at [this blog post](https://blog.q42.nl/the-imagepreview-library-render-previews-with-only-200-bytes-of-image-data-312fb281d081) for more details.
 
 You can find the [.NET server component on Github](https://github.com/Q42/Q42.ImagePreview.swift).
 


### PR DESCRIPTION
I assumed this is the correct link as it was the only one I could find about image previewing.